### PR TITLE
ci: add GitHub Actions CI workflow for lint, typecheck, and build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,60 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [master]
+  push:
+    branches: [master]
+
+jobs:
+  ci:
+    name: Lint, Typecheck & Build
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: flatrate
+          POSTGRES_PASSWORD: flatrate_password
+          POSTGRES_DB: rateyourflat
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      DATABASE_URL: postgresql://flatrate:flatrate_password@localhost:5432/rateyourflat
+      NEXTAUTH_SECRET: ci-secret-at-least-32-characters-long
+      NEXTAUTH_URL: http://localhost:3000
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Generate Prisma client
+        run: ./node_modules/.bin/prisma generate
+
+      - name: Push database schema
+        run: ./node_modules/.bin/prisma db push
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Build
+        run: npm run build


### PR DESCRIPTION
Runs on every PR to master and every push to master. Spins up a Postgres 16 service container, generates the Prisma client, pushes the schema, then runs lint -> typecheck -> build in order so failures are reported as separate check names.